### PR TITLE
Enhance sticker docs and script

### DIFF
--- a/prompt v3.md
+++ b/prompt v3.md
@@ -366,6 +366,20 @@ If no subcommand is matched, performs the default action (e.g., fetching data fo
 -   **Error Handling**: Provide clear messages for invalid subcommands or missing arguments.
 -   **Documentation**: Update the main script docstring and the command's `usage`/`description` to reflect the subcommand structure.
 
+#### 4.3.2 Sending Stickers
+
+Discord allows bots to send both built-in and custom stickers. Use the `stickers` parameter of `ctx.send` and retrieve the sticker from the cache before falling back to an HTTP fetch. This avoids unnecessary network calls and speeds up repeat usage.
+
+```python
+STICKER_ID = 749054660769218631  # example ID for the "wave" sticker
+sticker = bot.get_sticker(STICKER_ID)
+if not sticker:
+    sticker = await bot.fetch_sticker(STICKER_ID)
+await ctx.send(stickers=[sticker])
+```
+
+`bot.get_sticker` returns `None` if the sticker is not cached. For custom stickers—those uploaded to a guild you have access to—you may need to fetch them the first time with `fetch_sticker`. Once fetched, they remain in the cache for subsequent calls to `get_sticker`.
+
 ### 4.4 Event Listeners (@bot.listen)
 
 Handle Discord events using the `@bot.listen` decorator:
@@ -980,3 +994,4 @@ Scripts focused on loading, saving, and managing data stored in JSON files, ofte
 
 ### 6.6 User and Member Interaction
 Work with specific, accessible users - not global user databases. Due to Discord API limitations (as noted in Section 1), scripts cannot scan across all servers for mutual friends or build comprehensive user databases. Instead, focus on interacting with users who send messages in accessible channels or are explicitly specified by ID.
+

--- a/wave_sticker_script.py
+++ b/wave_sticker_script.py
@@ -1,0 +1,55 @@
+@nightyScript(
+    name="Wave Sticker",
+    author="AutoGPT",
+    description="Send the wave sticker.",
+    usage="<p>wave"
+)
+def script_function():
+    """
+    WAVE STICKER SCRIPT
+    -------------------
+
+    Sends stickers on command.
+
+    COMMANDS:
+    <p>wave - Send the wave sticker
+    <p>sticker <id> - Send any sticker by ID
+
+    EXAMPLES:
+    <p>wave - Bot replies with the wave sticker
+
+    NOTES:
+    - Sticker ID: 749054660769218631
+    - Attempts to use the cached sticker first, then fetches if needed
+    - Works with custom stickers as long as the bot can access them
+    """
+    STICKER_ID = 749054660769218631
+
+    @bot.command(name="wave", description="Send the wave sticker.")
+    async def wave_cmd(ctx):
+        await ctx.message.delete()
+        try:
+            sticker = bot.get_sticker(STICKER_ID)
+            if not sticker:
+                sticker = await bot.fetch_sticker(STICKER_ID)
+            await ctx.send(stickers=[sticker])
+        except Exception as e:
+            await ctx.send(f"Failed to send sticker: {e}")
+
+    @bot.command(name="sticker", description="Send any sticker by ID.")
+    async def custom_sticker_cmd(ctx, sticker_id: str):
+        await ctx.message.delete()
+        try:
+            sid = int(sticker_id)
+        except ValueError:
+            await ctx.send("Sticker ID must be an integer.")
+            return
+        try:
+            sticker = bot.get_sticker(sid)
+            if not sticker:
+                sticker = await bot.fetch_sticker(sid)
+            await ctx.send(stickers=[sticker])
+        except Exception as e:
+            await ctx.send(f"Failed to send sticker: {e}")
+
+script_function()


### PR DESCRIPTION
## Summary
- move sticker docs into a new `4.3.2 Sending Stickers` section
- explain custom stickers and caching vs. fetching
- extend `wave_sticker_script.py` with a command for arbitrary sticker IDs

## Testing
- `python3 -m py_compile wave_sticker_script.py`


------
https://chatgpt.com/codex/tasks/task_e_683f7115b28c8320bff730de6a40f443