### PR TITLE
Add website screenshot app

### DIFF
--- a/website-screenshot/Dockerfile
+++ b/website-screenshot/Dockerfile
@@ -1,0 +1,19 @@
+# Simple Dockerfile to run the website screenshot app
+FROM node:18-slim
+
+# Install minimal dependencies for running Chromium
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libnss3 libatk1.0-0 libatk-bridge2.0-0 libx11-xcb1 \
+        libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 \
+        libgbm1 libasound2 libpangocairo-1.0-0 libpangoft2-1 \
+        libdrm2 libgtk-3-0 ca-certificates fonts-liberation \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY screenshot.js ./
+
+ENTRYPOINT ["node", "screenshot.js"]
+CMD ["https://example.com", "screenshot.png"]

--- a/website-screenshot/README.md
+++ b/website-screenshot/README.md
@@ -1,0 +1,36 @@
+# Website Screenshot App
+
+This example demonstrates how to capture a screenshot of a web page using Node.js and [Puppeteer](https://github.com/puppeteer/puppeteer). The app can run directly with Node or inside a Docker container.
+
+## Requirements
+- Node.js (v18 or later)
+- Internet access to download page assets
+
+## Usage
+
+### Directly with Node.js
+
+Install dependencies and run:
+
+```bash
+npm install
+node screenshot.js <url> [output]
+```
+
+This saves a screenshot of `<url>` to `output` (default `screenshot.png`).
+
+### With Docker
+
+Build the container:
+
+```bash
+docker build -t website-screenshot .
+```
+
+Run it, passing the URL and optional output path:
+
+```bash
+docker run --rm -v $(pwd):/app website-screenshot "https://example.com" "out.png"
+```
+
+The screenshot will be written to `out.png` in your current directory.

--- a/website-screenshot/package.json
+++ b/website-screenshot/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "website-screenshot-app",
+  "version": "1.0.0",
+  "description": "Simple Node.js app to screenshot websites using Puppeteer",
+  "main": "screenshot.js",
+  "scripts": {
+    "start": "node screenshot.js"
+  },
+  "dependencies": {
+    "puppeteer": "^21.3.8"
+  }
+}

--- a/website-screenshot/screenshot.js
+++ b/website-screenshot/screenshot.js
@@ -1,0 +1,19 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const url = process.argv[2];
+  const output = process.argv[3] || 'screenshot.png';
+  if (!url) {
+    console.error('Usage: node screenshot.js <url> [output]');
+    process.exit(1);
+  }
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  const page = await browser.newPage();
+  await page.goto(url, { waitUntil: 'networkidle2' });
+  await page.screenshot({ path: output, fullPage: true });
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add a small Node-based example for capturing website screenshots
- include a Dockerfile for container use

## Testing
- `npm install --omit=dev`
- `node screenshot.js http://example.com test.png`

------
https://chatgpt.com/codex/tasks/task_e_6847dfbcb9b48320963ef7d810325021