### PR TITLE
Update README with external dependency guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You may use objects like `discord.File` without importing them — NightyScript 
 * External Python packages (e.g. `pydub`, `numpy`, `matplotlib`) are not allowed, unless they are non-Python tools like Docker.
 * All dependencies must be documented inside the script's docstring.
 
-### 1.2.1 External Dependencies for Custom Scripts
+#### 1.2.1 External Dependencies for Custom Scripts
 
 Custom scripts in this repository may use external dependencies including:
 - Python packages: `selenium`, `beautifulsoup4`, `requests`, `pandas`, etc.


### PR DESCRIPTION
## Summary
- allow scripts to use external packages and tools

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849333376a0832087e857c2f21020f7