### PR TITLE
Add Puppeteer screenshot example

### DIFF
--- a/example-scripts/webscrape/README.md
+++ b/example-scripts/webscrape/README.md
@@ -1,0 +1,39 @@
+# Web Scrape Examples
+
+This folder contains sample scripts that demonstrate simple web scraping using external dependencies.
+
+## GitHub Trending Fetcher
+
+Fetches names of the top trending repositories on GitHub.
+
+### Installation
+
+```
+pip install requests beautifulsoup4
+```
+
+### Usage
+
+Load the script in NightyScript and run:
+
+```
+<p>trending
+```
+
+## Puppeteer Screenshot
+
+Uses Node.js and Puppeteer to capture a screenshot of any webpage.
+
+### Installation
+
+```
+npm install puppeteer
+```
+
+### Usage
+
+Load the script in NightyScript and run:
+
+```
+<p>puppshot https://example.com
+```

--- a/example-scripts/webscrape/github_trending.py
+++ b/example-scripts/webscrape/github_trending.py
@@ -1,0 +1,45 @@
+@nightyScript(
+    name="GitHub Trending Fetcher",
+    author="AutoGPT",
+    description="Fetches top GitHub trending repositories",
+    usage="<p>trending",
+)
+def github_trending_fetcher():
+    """
+    GitHub Trending Fetcher
+    -----------------------
+
+    Fetches the titles of trending repositories from GitHub using requests and BeautifulSoup.
+
+    COMMANDS:
+    <p>trending - Fetch trending repository names from GitHub
+
+    EXAMPLE:
+    <p>trending
+
+    NOTES:
+    - Requires `requests` and `beautifulsoup4` packages.
+    - Install with: `pip install requests beautifulsoup4`
+    - Uses synchronous HTTP requests with requests library.
+    """
+
+    import requests
+    from bs4 import BeautifulSoup
+
+    @bot.command(name="trending", description="Fetch GitHub trending repositories")
+    async def trending_command(ctx):
+        await ctx.message.delete()
+
+        url = "https://github.com/trending"
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+        if resp.status_code != 200:
+            await ctx.send(f"Failed to fetch trending page (status {resp.status_code})")
+            return
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        repo_names = [a.text.strip() for a in soup.select('h1.h3 a')]
+        top_repos = repo_names[:5]
+        formatted = "\n".join(top_repos) if top_repos else "No repositories found"
+        await ctx.send(f"Top GitHub Trending Repos:\n```\n{formatted}\n```")
+
+github_trending_fetcher()

--- a/example-scripts/webscrape/puppeteer_screenshot.js
+++ b/example-scripts/webscrape/puppeteer_screenshot.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const [url, output] = process.argv.slice(2);
+  if (!url || !output) {
+    console.error('Usage: node puppeteer_screenshot.js <url> <output>');
+    process.exit(1);
+  }
+  const browser = await puppeteer.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    await page.screenshot({ path: output, fullPage: true });
+  } catch (err) {
+    console.error(err.toString());
+    process.exit(1);
+  } finally {
+    await browser.close();
+  }
+})();

--- a/example-scripts/webscrape/puppeteer_screenshot.py
+++ b/example-scripts/webscrape/puppeteer_screenshot.py
@@ -1,0 +1,60 @@
+@nightyScript(
+    name="Puppeteer Screenshot",
+    author="AutoGPT",
+    description="Capture a website screenshot using Node.js Puppeteer",
+    usage="<p>puppshot <url>"
+)
+def puppeteer_screenshot():
+    """
+    Puppeteer Screenshot
+    --------------------
+
+    Captures a screenshot of a webpage using Node.js Puppeteer.
+
+    COMMANDS:
+    <p>puppshot <url> - Capture the given URL as an image
+
+    EXAMPLE:
+    <p>puppshot https://example.com
+
+    NOTES:
+    - Requires Node.js and the `puppeteer` package.
+    - Install with: `npm install puppeteer`
+    - Python calls a Node script to generate the screenshot.
+    """
+    import asyncio
+    import discord
+    import os
+    from pathlib import Path
+    import uuid
+
+    JS_FILE = Path(__file__).with_name("puppeteer_screenshot.js")
+
+    async def run_puppeteer(url: str, out_file: Path) -> bool:
+        proc = await asyncio.create_subprocess_exec(
+            "node", str(JS_FILE), url, str(out_file)
+        )
+        await proc.communicate()
+        return proc.returncode == 0 and out_file.exists()
+
+    @bot.command(name="puppshot", aliases=["pshot"], description="Screenshot a webpage using Puppeteer")
+    async def puppshot_command(ctx, *, url: str):
+        await ctx.message.delete()
+        url = url.strip()
+        if not url.startswith("http://") and not url.startswith("https://"):
+            url = "http://" + url
+        temp_file = Path(os.getcwd()) / f"puppshot_{uuid.uuid4().hex}.png"
+        status_msg = await ctx.send(f"Capturing screenshot for {url}...")
+        success = await run_puppeteer(url, temp_file)
+        if not success:
+            await status_msg.edit(content="Failed to capture screenshot.")
+            return
+        file = discord.File(str(temp_file), filename="screenshot.png")
+        await status_msg.delete()
+        await ctx.send(file=file)
+        try:
+            temp_file.unlink()
+        except OSError:
+            pass
+
+puppeteer_screenshot()


### PR DESCRIPTION
## Summary
- add a Puppeteer-based screenshot command
- document setup and usage in the webscrape README

## Testing
- `python -m py_compile example-scripts/webscrape/puppeteer_screenshot.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684935b913588320a346bd029f319023